### PR TITLE
Block hash or meta hash in transition mapping ?

### DIFF
--- a/packages/protocol/contracts/L1/BasedOperator.sol
+++ b/packages/protocol/contracts/L1/BasedOperator.sol
@@ -140,10 +140,8 @@ contract BasedOperator is EssentialContract, TaikoErrors {
             proofBatch.blockMetadata.l2BlockNumber, proofBatch.transition.parentBlockHash
         );
 
-        // Brecht: SO we set the blockHash in proposeBlock().
-        // But we need to prove it too (the same one), so somehow we need to check if this is proven
-        // already and IF NOT, then revert with "block already proven", no ? So i set the
-        // verifiableAfter in propseBlock to 0, because this is just a "proposed state".
+        // Somehow we need to check if this is proven already and IF YES and transition is trying to
+        // prove the same, then revert with "block already proven".
         if (
             storedTransition.isProven == true
                 && storedTransition.blockHash == proofBatch.transition.blockHash

--- a/packages/protocol/contracts/L1/BasedOperator.sol
+++ b/packages/protocol/contracts/L1/BasedOperator.sol
@@ -137,7 +137,7 @@ contract BasedOperator is EssentialContract, TaikoErrors {
         // invalid
         // Get the currently stored transition
         TaikoData.TransitionState memory storedTransition = taiko.getTransition(
-            proofBatch.blockMetadata.l2BlockNumber, proofBatch.transition.parentHash
+            proofBatch.blockMetadata.l2BlockNumber, proofBatch.transition.parentBlockHash
         );
 
         // Brecht: SO we set the blockHash in proposeBlock().

--- a/packages/protocol/contracts/L1/BasedOperator.sol
+++ b/packages/protocol/contracts/L1/BasedOperator.sol
@@ -108,13 +108,13 @@ contract BasedOperator is EssentialContract, TaikoErrors {
         }
 
         VerifierRegistry verifierRegistry = VerifierRegistry(resolve("verifier_registry", false));
-        TaikoL1 taiko = TaikoL1(resolve("taiko", false));   
+        TaikoL1 taiko = TaikoL1(resolve("taiko", false));
         // Verify the proofs
         uint160 prevVerifier = uint160(0);
         for (uint256 i = 0; i < proofBatch.proofs.length; i++) {
             IVerifier verifier = proofBatch.proofs[i].verifier;
             // Make sure each verifier is unique
-            if(prevVerifier >= uint160(address(verifier))) {
+            if (prevVerifier >= uint160(address(verifier))) {
                 revert L1_INVALID_OR_DUPLICATE_VERIFIER();
             }
             // Make sure it's a valid verifier
@@ -140,18 +140,16 @@ contract BasedOperator is EssentialContract, TaikoErrors {
             proofBatch.blockMetadata.l2BlockNumber, proofBatch.transition.parentHash
         );
 
-        console2.log("What is stored:");
-        console2.logBytes32(storedTransition.blockHash);
-
-        console2.log("What we are trying to prove:");
-        console2.logBytes32(proofBatch.transition.blockHash);
-        
         // Brecht: SO we set the blockHash in proposeBlock().
-        // But we need to prove it too (the same one), so somehow we need to check if this is proven already and IF NOT, then revert with "block already proven", no ? So i set the verifiableAfter in propseBlock to 0, because this is just a "proposed state".
-        if (storedTransition.isProven == true && storedTransition.blockHash == proofBatch.transition.blockHash) {
+        // But we need to prove it too (the same one), so somehow we need to check if this is proven
+        // already and IF NOT, then revert with "block already proven", no ? So i set the
+        // verifiableAfter in propseBlock to 0, because this is just a "proposed state".
+        if (
+            storedTransition.isProven == true
+                && storedTransition.blockHash == proofBatch.transition.blockHash
+        ) {
             revert("block already proven");
-        }
-        else {
+        } else {
             // TODO(Brecht): Check that one of the verifiers is now poissoned
         }
 

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -23,6 +23,7 @@ library TaikoData {
     /// @dev Struct containing data only required for proving a block
     struct BlockMetadata {
         bytes32 blockHash;
+        bytes32 parentBlockHash;
         bytes32 parentMetaHash;
         bytes32 l1Hash;
         uint256 difficulty;
@@ -40,13 +41,13 @@ library TaikoData {
 
     /// @dev Struct representing transition to be proven.
     struct Transition {
-        bytes32 parentHash;
+        bytes32 parentBlockHash;
         bytes32 blockHash;
     }
 
     /// @dev Struct representing state transition data.
     struct TransitionState {
-        bytes32 blockHash;
+        bytes32 blockHash; //Might be removed..
         uint64 timestamp;
         address prover;
         uint64 verifiableAfter;
@@ -65,8 +66,7 @@ library TaikoData {
     /// @dev Struct holding the state variables for the {TaikoL1} contract.
     struct State {
         mapping(uint256 blockId => Block) blocks;
-        // Todo (Brecht): please check which one to use here (?) metaHash or blockHash
-        mapping(uint256 blockId => mapping(bytes32 parentMetaHash => TransitionState)) transitions;
+        mapping(uint256 blockId => mapping(bytes32 parentBlockHash => TransitionState)) transitions;
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 numBlocks;

--- a/packages/protocol/contracts/L1/TaikoData.sol
+++ b/packages/protocol/contracts/L1/TaikoData.sol
@@ -65,7 +65,8 @@ library TaikoData {
     /// @dev Struct holding the state variables for the {TaikoL1} contract.
     struct State {
         mapping(uint256 blockId => Block) blocks;
-        mapping(uint256 blockId => mapping(bytes32 parentBlockHash => TransitionState)) transitions;
+        // Todo (Brecht): please check which one to use here (?) metaHash or blockHash
+        mapping(uint256 blockId => mapping(bytes32 parentMetaHash => TransitionState)) transitions;
         uint64 genesisHeight;
         uint64 genesisTimestamp;
         uint64 numBlocks;

--- a/packages/protocol/contracts/L1/TaikoErrors.sol
+++ b/packages/protocol/contracts/L1/TaikoErrors.sol
@@ -20,6 +20,7 @@ abstract contract TaikoErrors {
     error L1_BLOB_NOT_FOUND();
     error L1_BLOB_NOT_REUSEABLE();
     error L1_BLOCK_MISMATCH();
+    error L1_INCORRECT_BLOCK();
     error L1_INSUFFICIENT_TOKEN();
     error L1_INVALID_ADDRESS();
     error L1_INVALID_AMOUNT();

--- a/packages/protocol/contracts/L1/VerifierBattleRoyale.sol
+++ b/packages/protocol/contracts/L1/VerifierBattleRoyale.sol
@@ -84,7 +84,10 @@ contract VerifierBattleRoyale is EssentialContract {
 
             TaikoData.Transition memory transitionA = proofBatch.proofs[0].transition;
             TaikoData.Transition memory transitionB = proofBatch.proofs[1].transition;
-            require(transitionA.parentHash == transitionB.parentHash, "parentHash not the same");
+            require(
+                transitionA.parentBlockHash == transitionB.parentBlockHash,
+                "parentHash not the same"
+            );
             require(transitionA.blockHash != transitionB.blockHash, "blockhash the same");
         } else if (proofBatch.proofs.length == 3) {
             /* Multiple verifiers in a consensus show that another verifier is faulty */
@@ -105,7 +108,10 @@ contract VerifierBattleRoyale is EssentialContract {
             for (uint256 i = 0; i < proofBatch.proofs.length - 1; i++) {
                 TaikoData.Transition memory transitionA = proofBatch.proofs[i].transition;
                 TaikoData.Transition memory transitionB = proofBatch.proofs[i + 1].transition;
-                require(transitionA.parentHash == transitionB.parentHash, "parentHash not the same");
+                require(
+                    transitionA.parentBlockHash == transitionB.parentBlockHash,
+                    "parentHash not the same"
+                );
                 if (i < proofBatch.proofs.length - 2) {
                     require(transitionA.blockHash == transitionB.blockHash, "blockhash the same");
                 } else {

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -19,7 +19,7 @@ contract TaikoL1Test is TaikoL1TestBase {
 
         // console2.log(block.number);
         // meta.blockHash = randBytes32();
-        // meta.parentMetaHash = GENESIS_BLOCK_HASH;
+        // meta.parentHash = GENESIS_BLOCK_HASH;
         // meta.l1Hash = blockhash(block.number - 1);
         // meta.difficulty = block.prevrandao;
         // meta.blobHash = randBytes32();
@@ -32,22 +32,24 @@ contract TaikoL1Test is TaikoL1TestBase {
         // meta.txListByteOffset = 0;
         // meta.txListByteSize = 0;
         // meta.blobUsed = true;
-
+        bytes32 parentMetaHash;
         for (uint64 blockId = 1; blockId <= 1; blockId++) {
             printVariables("before propose");
-            meta = createBlockMetaData(Alice, blockId, 1, true);
+            // Create metadata and propose the block
+            meta = createBlockMetaData(parentMetaHash, Alice, blockId, 1, true);
             proposeBlock(Alice, Alice, meta);
-            printVariables("after propose");
 
+            // Create proofs and prove a block
             BasedOperator.ProofBatch memory blockProofs = createProofs(meta, Alice, true);
-
             proveBlock(Alice, abi.encode(blockProofs));
 
-            // bytes32 blockHash = bytes32(1e10 + blockId);
-            // bytes32 stateRoot = bytes32(1e9 + blockId);
+            //Wait enought time and verify block
+            vm.warp(uint32(block.timestamp + L1.SECURITY_DELAY_AFTER_PROVEN() + 1));
+            vm.roll(block.number + 10);
+            verifyBlock(1);
+            printVariables("after verify");
 
-            // proveBlock(Alice, meta, parentHash, blockHash, stateRoot, meta.minTier, "");
-            // parentHash = blockHash;
+            parentMetaHash = keccak256(abi.encode(meta));
         }
     }
 }

--- a/packages/protocol/test/L1/TaikoL1.t.sol
+++ b/packages/protocol/test/L1/TaikoL1.t.sol
@@ -9,7 +9,7 @@ contract TaikoL1Test is TaikoL1TestBase {
             TaikoL1(payable(deployProxy({ name: "taiko", impl: address(new TaikoL1()), data: "" })));
     }
 
-    function test_L1_proposeBlock() external {
+    function test_L1_propose_prove_and_verify_blocks_sequentially() external {
         giveEthAndTko(Alice, 100 ether, 100 ether);
 
         TaikoData.BlockMetadata memory meta;
@@ -17,27 +17,12 @@ contract TaikoL1Test is TaikoL1TestBase {
         vm.roll(block.number + 1);
         vm.warp(block.timestamp + 12);
 
-        // console2.log(block.number);
-        // meta.blockHash = randBytes32();
-        // meta.parentHash = GENESIS_BLOCK_HASH;
-        // meta.l1Hash = blockhash(block.number - 1);
-        // meta.difficulty = block.prevrandao;
-        // meta.blobHash = randBytes32();
-        // meta.coinbase = Alice;
-        // meta.l2BlockNumber = 1;
-        // meta.gasLimit = L1.getConfig().blockMaxGasLimit;
-        // meta.l1StateBlockNumber = uint32(block.number-1);
-        // meta.timestamp = uint64(block.timestamp - 12); // 1 block behind
-
-        // meta.txListByteOffset = 0;
-        // meta.txListByteSize = 0;
-        // meta.blobUsed = true;
         bytes32 parentMetaHash;
-        for (uint64 blockId = 1; blockId <= 1; blockId++) {
-            printVariables("before propose");
+        for (uint64 blockId = 1; blockId <= 20; blockId++) {
+            printVariables("before propose & prove & verify");
             // Create metadata and propose the block
-            meta = createBlockMetaData(parentMetaHash, Alice, blockId, 1, true);
-            proposeBlock(Alice, Alice, meta);
+            meta = createBlockMetaData(Alice, blockId, 1, true);
+            proposeBlock(Alice, Alice, meta, "");
 
             // Create proofs and prove a block
             BasedOperator.ProofBatch memory blockProofs = createProofs(meta, Alice, true);
@@ -47,9 +32,58 @@ contract TaikoL1Test is TaikoL1TestBase {
             vm.warp(uint32(block.timestamp + L1.SECURITY_DELAY_AFTER_PROVEN() + 1));
             vm.roll(block.number + 10);
             verifyBlock(1);
-            printVariables("after verify");
-
             parentMetaHash = keccak256(abi.encode(meta));
+            printVariables("after verify");
         }
+    }
+
+    function test_L1_propose_some_blocks_in_a_row_then_prove_and_verify() external {
+        giveEthAndTko(Alice, 100 ether, 100 ether);
+
+        TaikoData.BlockMetadata[] memory blockMetaDatas = new TaikoData.BlockMetadata[](20);
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12);
+
+        bytes32 parentMetaHash;
+        for (uint64 blockId = 1; blockId <= 20; blockId++) {
+            printVariables("before propose & prove & verify");
+            // Create metadata and propose the block
+            blockMetaDatas[blockId - 1] = createBlockMetaData(Alice, blockId, 1, true);
+            proposeBlock(Alice, Alice, blockMetaDatas[blockId - 1], "");
+            vm.roll(block.number + 1);
+            vm.warp(block.timestamp + 12);
+        }
+
+        for (uint64 blockId = 1; blockId <= 20; blockId++) {
+            // Create proofs and prove a block
+            BasedOperator.ProofBatch memory blockProofs =
+                createProofs(blockMetaDatas[blockId - 1], Alice, true);
+            proveBlock(Alice, abi.encode(blockProofs));
+
+            //Wait enought time and verify block (currently we simply just "wait enough" from latest
+            // block and not time it perfectly)
+            vm.warp(uint32(block.timestamp + L1.SECURITY_DELAY_AFTER_PROVEN() + 1));
+            vm.roll(block.number + 10);
+            verifyBlock(1);
+            parentMetaHash = keccak256(abi.encode(blockMetaDatas[blockId - 1]));
+            printVariables("after verify 1");
+        }
+    }
+
+    function test_L1_propose_block_outside_the_4_epoch_window() external {
+        giveEthAndTko(Alice, 100 ether, 100 ether);
+
+        TaikoData.BlockMetadata memory meta;
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12);
+
+        // Create metadata and propose the block 129 blocks later only
+        meta = createBlockMetaData(Alice, 1, 1, true);
+        vm.roll(block.number + 129);
+        vm.warp(block.timestamp + 129 * 12);
+
+        proposeBlock(Alice, Alice, meta, TaikoErrors.L1_INVALID_L1_STATE_BLOCK.selector);
     }
 }


### PR DESCRIPTION
@Brechtpd  i commented your name where i'd need help. Currently it verifies everything.. So for example it verifies the first block after it is proposed.

First because of the blockHash, while i use metaHash, but also, since i used this: bytes32 blockHash = blk.metaHash;... i dont get why the first block `state.transitions[blockId][blockHash].blockHash == bytes32(0)` equals to true now.. (since i set the `metaHash` as blockHash)

```
            if (
state.tansitions[blockId][blockHash].blockHash == bytes32(0)
                    || block.timestamp < state.transitions[blockId][blockHash].verifiableAfter
            ) {
                break;
            }
```