### PR TITLE
add k256 feature for signer recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7706,6 +7706,7 @@ dependencies = [
  "c-kzg 1.0.2",
  "criterion",
  "derive_more",
+ "k256",
  "modular-bitfield",
  "nybbles",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,6 +478,7 @@ secp256k1 = { version = "0.29", default-features = false, features = [
     "global-context",
     "recovery",
 ] }
+k256 = "0.13"
 # TODO: Remove `k256` feature: https://github.com/sigp/enr/pull/74
 enr = { version = "0.12.0", default-features = false, features = [
     "k256",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -37,6 +37,7 @@ secp256k1 = { workspace = true, features = [
     "recovery",
     "rand",
 ] }
+k256 = { workspace = true, optional = true }
 # for eip-4844
 c-kzg = { workspace = true, features = ["serde"], optional = true }
 
@@ -129,6 +130,7 @@ alloy-compat = [
 ]
 std = ["thiserror-no-std/std"]
 test-utils = ["reth-primitives-traits/test-utils"]
+k256 = ["dep:k256"]
 
 [[bench]]
 name = "recover_ecdsa_crit"

--- a/crates/primitives/src/revm/env.rs
+++ b/crates/primitives/src/revm/env.rs
@@ -82,6 +82,11 @@ pub enum CliqueSignerRecoveryError {
     #[error("Invalid extra data length")]
     InvalidExtraData,
     /// Recovery failed.
+    #[cfg(feature = "k256")]
+    #[error("Invalid signature: {0}")]
+    InvalidSignature(#[from] k256::ecdsa::Error),
+    /// Recovery failed.
+    #[cfg(not(feature = "k256"))]
     #[error("Invalid signature: {0}")]
     InvalidSignature(#[from] secp256k1::Error),
 }
@@ -212,7 +217,11 @@ fn fill_tx_env_with_system_contract_call(
             enveloped_tx: Some(Bytes::default()),
         },
         #[cfg(feature = "taiko")]
-        taiko: revm_primitives::TaikoFields { treasury: Address::default(), is_anchor: false, basefee_ratio: 0u8 },
+        taiko: revm_primitives::TaikoFields {
+            treasury: Address::default(),
+            is_anchor: false,
+            basefee_ratio: 0u8,
+        },
     };
 
     // ensure the block gas limit is >= the tx

--- a/crates/primitives/src/transaction/util.rs
+++ b/crates/primitives/src/transaction/util.rs
@@ -2,10 +2,7 @@ pub(crate) mod secp256k1 {
     use super::*;
     use crate::{keccak256, Address, Signature};
     pub(crate) use ::secp256k1::Error;
-    use ::secp256k1::{
-        ecdsa::{RecoverableSignature, RecoveryId},
-        Message, PublicKey, SecretKey, SECP256K1,
-    };
+    use ::secp256k1::{Message, SecretKey, SECP256K1};
     use revm_primitives::{B256, U256};
 
     /// Recovers the address of the sender using secp256k1 pubkey recovery.
@@ -14,12 +11,42 @@ pub(crate) mod secp256k1 {
     ///
     /// This does not ensure that the `s` value in the signature is low, and _just_ wraps the
     /// underlying secp256k1 library.
+    #[cfg(not(feature = "k256"))]
     pub fn recover_signer_unchecked(sig: &[u8; 65], msg: &[u8; 32]) -> Result<Address, Error> {
+        use ::secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
         let sig =
             RecoverableSignature::from_compact(&sig[0..64], RecoveryId::from_i32(sig[64] as i32)?)?;
 
         let public = SECP256K1.recover_ecdsa(&Message::from_digest(*msg), &sig)?;
         Ok(public_key_to_address(public))
+    }
+
+    /// Recovers the address of the sender using secp256k1 pubkey recovery.
+    ///
+    /// Converts the public key into an ethereum address by hashing the public key with keccak256.
+    ///
+    /// This does not ensure that the `s` value in the signature is low, and _just_ wraps the
+    /// underlying secp256k1 library.
+    #[cfg(feature = "k256")]
+    pub fn recover_signer_unchecked(
+        sig: &[u8; 65],
+        msg: &[u8; 32],
+    ) -> Result<Address, k256::ecdsa::Error> {
+        use k256::ecdsa::{RecoveryId, VerifyingKey};
+
+        let mut signature = k256::ecdsa::Signature::from_slice(&sig[0..64])?;
+        let mut recid = sig[64];
+
+        // normalize signature and flip recovery id if needed.
+        if let Some(sig_normalized) = signature.normalize_s() {
+            signature = sig_normalized;
+            recid ^= 1;
+        }
+        let recid = RecoveryId::from_byte(recid).expect("recovery ID is valid");
+
+        // recover key
+        let recovered_key = VerifyingKey::recover_from_prehash(&msg[..], &signature, recid)?;
+        Ok(public_key_to_address(recovered_key))
     }
 
     /// Signs message with the given secret key.
@@ -39,10 +66,19 @@ pub(crate) mod secp256k1 {
 
     /// Converts a public key into an ethereum address by hashing the encoded public key with
     /// keccak256.
-    pub fn public_key_to_address(public: PublicKey) -> Address {
+    #[cfg(not(feature = "k256"))]
+    pub fn public_key_to_address(public: ::secp256k1::PublicKey) -> Address {
         // strip out the first byte because that should be the SECP256K1_TAG_PUBKEY_UNCOMPRESSED
         // tag returned by libsecp's uncompressed pubkey serialization
         let hash = keccak256(&public.serialize_uncompressed()[1..]);
+        Address::from_slice(&hash[12..])
+    }
+
+    /// Converts a public key into an ethereum address by hashing the encoded public key with
+    /// keccak256.
+    #[cfg(feature = "k256")]
+    pub fn public_key_to_address(public: k256::ecdsa::VerifyingKey) -> Address {
+        let hash = keccak256(&public.to_encoded_point(/* compress = */ false).as_bytes()[1..]);
         Address::from_slice(&hash[12..])
     }
 }


### PR DESCRIPTION
Changes intended to be kept as minimal and non-breaking to existing workflows. This is just needed to be able to use k256 for signature verification (to be more effectively accelerated).

The implementation was taken roughly from upstream reth, with some slight modifications. Changes could be more involved to remove secp256k1 from the dependency tree and default to k256 like upstream reth, but defaulting to not for now.

These changes are necessary for a raiko optimization for risc0 prover.