### PR TITLE
fix(evm): skip anchor success check for early mainnet Shasta proposals

### DIFF
--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -307,7 +307,19 @@ where
             if is_taiko {
                 if is_anchor && !optimistic {
                     if !result.is_success() {
-                        return Err(BlockExecutionError::msg("anchor transaction must be success"));
+                        // On mainnet, the first Shasta proposals had reverted anchor txs
+                        // due to bootstrapping. Allow those specific proposals through.
+                        let skip_anchor_check = taiko_data.shasta_data.as_ref().is_some_and(|sd| {
+                            sd.chain_id == crate::taiko::TAIKO_MAINNET_CHAIN_ID
+                                && sd.proposal_id <= crate::taiko::MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET
+                        });
+                        if !skip_anchor_check {
+                            return Err(BlockExecutionError::msg("anchor transaction must be success"));
+                        }
+                        warn!(
+                            proposal_id = taiko_data.shasta_data.as_ref().unwrap().proposal_id,
+                            "anchor transaction reverted but allowed for early mainnet proposal"
+                        );
                     } else {
                         // if it's shasta
                         if let Some(shasta_data) = taiko_data.shasta_data {

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -311,6 +311,7 @@ where
                         // due to bootstrapping. Allow those specific proposals through.
                         let skip_anchor_check = taiko_data.shasta_data.as_ref().is_some_and(|sd| {
                             sd.chain_id == crate::taiko::TAIKO_MAINNET_CHAIN_ID
+                                && sd.proposal_id >= 1
                                 && sd.proposal_id <= crate::taiko::MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET
                         });
                         if !skip_anchor_check {

--- a/crates/ethereum/evm/src/taiko.rs
+++ b/crates/ethereum/evm/src/taiko.rs
@@ -21,6 +21,12 @@ pub struct ProtocolBaseFeeConfig {
     pub max_gas_issuance_per_block: u32,
 }
 
+/// Taiko mainnet chain ID.
+pub const TAIKO_MAINNET_CHAIN_ID: u64 = 167_000;
+/// The maximum proposal ID (inclusive) for which anchor failure is tolerated on mainnet.
+/// The first Shasta proposals on mainnet had reverted anchor txs due to bootstrapping.
+pub const MAINNET_ANCHOR_CHECK_SKIP_PROPOSAL_OFFSET: u64 = 7;
+
 /// Shasta specific data
 #[derive(Clone, Debug, Default)]
 pub struct ShastaData {
@@ -30,6 +36,10 @@ pub struct ShastaData {
     pub is_force_inclusion: bool,
     /// is the first block in the proposal
     pub is_first_block_in_proposal: bool,
+    /// The proposal (batch) ID, used to skip anchor checks for early mainnet proposals.
+    pub proposal_id: u64,
+    /// The L2 chain ID, used together with proposal_id for mainnet-specific overrides.
+    pub chain_id: u64,
 }
 
 /// Data required to validate a Taiko Block


### PR DESCRIPTION
## Summary

- Add `proposal_id` and `chain_id` fields to `ShastaData` struct
- Conditionally skip the anchor tx success check for Taiko mainnet (chain ID 167000) proposals <= 7
- The first Shasta proposals on mainnet had reverted `anchorV4()` txs due to bootstrapping — this prevents provers from generating valid proofs, blocking finalization of the entire chain

## Context

The existing `ignore-anchor-failure` branch disables the anchor check for **all** proposals on all chains. This PR is a targeted replacement that only relaxes the check for the specific proposals affected on mainnet, keeping the consensus rule intact for everything else.

Constants align with `MainnetAnchorCheckSkipProposalOffset = 7` in [taiko-mono PR #21529](https://github.com/taikoxyz/taiko-mono/pull/21529).

## Companion PRs

- **raiko**: [taikoxyz/raiko — fix/targeted-anchor-skip](https://github.com/taikoxyz/raiko/compare/main...fix/targeted-anchor-skip) — threads `proposal_id` and `chain_id` from batch input into `ShastaData`
- **taiko-mono**: [#21529](https://github.com/taikoxyz/taiko-mono/pull/21529) — client-side driver fix for reading anchor state during bootstrapping

## Test plan

- [ ] Verify raiko can generate proofs for mainnet proposals 1-7 with this change
- [ ] Verify proofs for proposals >= 8 still require anchor tx success
- [ ] Verify non-mainnet chains (Hoodi, devnet) are unaffected
- [ ] End-to-end: submit proof to Inbox.prove() and confirm finalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)